### PR TITLE
Smaller indexing types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -311,6 +311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,18 +353,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -439,6 +449,7 @@ dependencies = [
  "clap",
  "fixedbitset",
  "kdam",
+ "memory-stats",
  "petgraph",
  "serde",
  "serde_json",
@@ -446,7 +457,6 @@ dependencies = [
  "tempfile",
  "test-temp-file",
  "type-layout",
- "ux",
 ]
 
 [[package]]
@@ -457,22 +467,22 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -514,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,16 +613,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "ux"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb3ff47e36907a6267572c1e398ff32ef78ac5131de8aa272e53846592c207e"
-
-[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rusty-dawg"
 version = "0.1.0"
 authors = ["lambdaviking"]
 repository = "https://github.com/viking-sudo-rm/rusty-dawg"
+edition = "2015"
 
 [dependencies]
 bincode = "1.3.3"
@@ -14,8 +15,8 @@ kdam = "0.3.0"
 petgraph = "0.6.3"
 serde = "1.0.163"
 serde_json = "1.0.96"
+memory-stats = "1.1.0"
 substring = "1.4.5"
 tempfile = "3.6.0"
 test-temp-file = "0.1.2"
 type-layout = "0.2.0"
-ux = "0.1.5"

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -10,6 +10,7 @@ use dawg::Dawg;
 use stat_utils::*;
 use weight::Weight;
 
+use crate::weight::weight40::DefaultWeight;
 use lms::LM;
 
 // TODO:
@@ -81,7 +82,7 @@ impl Evaluator<'_, usize> {
         }
     }
 
-    pub fn evaluate(&mut self, dawg: &Dawg<usize>, idx: usize, good_turing: f64) {
+    pub fn evaluate(&mut self, dawg: &Dawg<usize, DefaultWeight>, idx: usize, good_turing: f64) {
         // println!("=== eval@{} ===", idx);
         // println!("counts: {:?}", counts);
         // println!("{:?}", Dot::new(dawg.get_graph()));
@@ -134,7 +135,7 @@ impl Evaluator<'_, usize> {
                 cum_count += dawg.get_weight(state).get_count();
                 // cum_count += counts[state.index()];
             }
-            cum_entropy += get_entropy::<usize>(dawg, state);
+            cum_entropy += get_entropy::<usize, DefaultWeight>(dawg, state);
             num_tokens += 1;
 
             for lm in self.lms.iter_mut() {
@@ -169,6 +170,7 @@ mod tests {
     use graph::vec_graph::dot::Dot;
     use tokenize::{TokenIndex, Tokenize};
 
+    use crate::weight::weight40::DefaultWeight;
     use lms::kn_lm::KNLM;
     use lms::LM;
 
@@ -188,7 +190,7 @@ mod tests {
         let mut lms: Vec<Box<dyn LM>> = Vec::new();
         let mut evaluator: Evaluator<usize> = Evaluator::new(&mut lms, &test, 3);
 
-        let mut dawg: Dawg<usize> = Dawg::new();
+        let mut dawg: Dawg<usize, DefaultWeight> = Dawg::new();
         let mut last = dawg.get_initial();
         for (idx, token) in train.iter().enumerate() {
             last = dawg.extend(*token, last);
@@ -222,7 +224,7 @@ mod tests {
         lms.push(Box::new(unigram));
         let mut evaluator: Evaluator<usize> = Evaluator::new(&mut lms, &test, 3);
 
-        let mut dawg: Dawg<usize> = Dawg::new();
+        let mut dawg: Dawg<usize, DefaultWeight> = Dawg::new();
         let mut last = dawg.get_initial();
         for (idx, token) in train.iter().enumerate() {
             last = dawg.extend(*token, last);

--- a/src/graph/avl_graph/mod.rs
+++ b/src/graph/avl_graph/mod.rs
@@ -38,7 +38,7 @@ where
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         let node = Node::new(weight);
         let node_idx = NodeIndex::new(self.nodes.len());
-        assert!(<Ix as IndexType>::max().index() == !0 || NodeIndex::end() != node_idx);
+        assert!(<Ix as IndexType>::max_value().index() == !0 || NodeIndex::end() != node_idx);
         self.nodes.push(node);
         node_idx
     }

--- a/src/graph/vec_graph/mod.rs
+++ b/src/graph/vec_graph/mod.rs
@@ -42,7 +42,7 @@ where
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         let node = Node::new(weight);
         let node_idx = NodeIndex::new(self.nodes.len());
-        assert!(<Ix as IndexType>::max().index() == !0 || NodeIndex::end() != node_idx);
+        assert!(<Ix as IndexType>::max_value().index() == !0 || NodeIndex::end() != node_idx);
         self.nodes.push(node);
         node_idx
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate bincode;
 extern crate bitvec;
 extern crate kdam;
+extern crate memory_stats;
 extern crate petgraph;
 extern crate serde;
 extern crate serde_json;

--- a/src/lms/kn_lm.rs
+++ b/src/lms/kn_lm.rs
@@ -6,6 +6,7 @@ use weight::Weight;
 
 // use petgraph::graph::NodeIndex;
 use graph::indexing::NodeIndex;
+use weight::weight40::DefaultWeight;
 
 pub struct KNLM {
     pub name: String,
@@ -22,11 +23,16 @@ impl LM for KNLM {
         self.name.as_str()
     }
 
-    fn reset(&mut self, dawg: &Dawg<usize>) {
+    fn reset(&mut self, dawg: &Dawg<usize, DefaultWeight>) {
         self.state = dawg.get_initial();
     }
 
-    fn get_probability(&self, dawg: &Dawg<usize>, label: usize, good_turing: f64) -> f64 {
+    fn get_probability(
+        &self,
+        dawg: &Dawg<usize, DefaultWeight>,
+        label: usize,
+        good_turing: f64,
+    ) -> f64 {
         let mut state = self.state;
         let _initial = dawg.get_initial();
         while dawg.get_weight(state).get_count() < self.min_count {
@@ -38,7 +44,7 @@ impl LM for KNLM {
         self.get_probability_kn(dawg, state, label, good_turing)
     }
 
-    fn update(&mut self, dawg: &Dawg<usize>, label: usize) {
+    fn update(&mut self, dawg: &Dawg<usize, DefaultWeight>, label: usize) {
         self.state = dawg.transition(self.state, label, true).unwrap();
     }
 }
@@ -55,7 +61,12 @@ impl KNLM {
         }
     }
 
-    pub fn get_probability_exact(&self, dawg: &Dawg<usize>, state: NodeIndex, label: usize) -> f64 {
+    pub fn get_probability_exact(
+        &self,
+        dawg: &Dawg<usize, DefaultWeight>,
+        state: NodeIndex,
+        label: usize,
+    ) -> f64 {
         // FIXME: Handle <eos> here!!
         let denom = dawg.get_weight(state).get_count();
         let num = match dawg.transition(state, label, false) {
@@ -78,7 +89,7 @@ impl KNLM {
     // Backoff with Kneser-Ney smoothing
     pub fn get_probability_kn(
         &self,
-        dawg: &Dawg<usize>,
+        dawg: &Dawg<usize, DefaultWeight>,
         mut state: NodeIndex,
         label: usize,
         good_turing: f64,

--- a/src/lms/mod.rs
+++ b/src/lms/mod.rs
@@ -1,14 +1,20 @@
 pub mod induction_lm;
 pub mod kn_lm;
 
+use crate::weight::weight40::DefaultWeight;
 use dawg::Dawg;
 
 pub trait LM {
     fn get_name(&self) -> &str;
 
-    fn reset(&mut self, dawg: &Dawg<usize>);
+    fn reset(&mut self, dawg: &Dawg<usize, DefaultWeight>);
 
-    fn get_probability(&self, dawg: &Dawg<usize>, label: usize, good_turing: f64) -> f64;
+    fn get_probability(
+        &self,
+        dawg: &Dawg<usize, DefaultWeight>,
+        label: usize,
+        good_turing: f64,
+    ) -> f64;
 
-    fn update(&mut self, dawg: &Dawg<usize>, label: usize);
+    fn update(&mut self, dawg: &Dawg<usize, DefaultWeight>, label: usize);
 }

--- a/src/stat_utils.rs
+++ b/src/stat_utils.rs
@@ -2,13 +2,15 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ord;
 use std::fmt::Debug;
 
+use crate::weight::weight40::DefaultWeight;
 use dawg::Dawg;
 use graph::indexing::NodeIndex;
 use weight::Weight;
 
-pub fn get_entropy<E>(dawg: &Dawg<E>, state: NodeIndex) -> f64
+pub fn get_entropy<E, W>(dawg: &Dawg<E, W>, state: NodeIndex) -> f64
 where
     E: Eq + Ord + Serialize + for<'a> Deserialize<'a> + Copy + Debug,
+    W: Weight + Serialize + for<'a> Deserialize<'a>,
 {
     // let denom = counts[state.index()];
     // println!("{:?}", Dot::new(dawg.get_graph()));
@@ -36,7 +38,7 @@ where
     sum_prob
 }
 
-pub fn good_turing_estimate(dawg: &Dawg<usize>, n_tokens: usize) -> f64 {
+pub fn good_turing_estimate(dawg: &Dawg<usize, DefaultWeight>, n_tokens: usize) -> f64 {
     let mut n_once = 0;
     let graph = dawg.get_graph();
     for unigram in graph.neighbors(dawg.get_initial()) {
@@ -59,7 +61,7 @@ mod tests {
 
     #[test]
     fn test_get_entropy() {
-        let mut dawg = Dawg::new();
+        let mut dawg: Dawg<char, DefaultWeight> = Dawg::new();
         dawg.build(&"ab".chars().collect());
         // Approximately log_2(3)
         assert_eq!(get_entropy(&dawg, NodeIndex::new(0)), 1.584962500721156);

--- a/src/weight/mod.rs
+++ b/src/weight/mod.rs
@@ -42,4 +42,4 @@ pub mod basic_weight;
 pub use self::basic_weight::BasicWeight;
 
 pub mod weight40;
-pub use self::weight40::Weight40;
+pub use self::weight40::{Weight40, WeightMinimal};


### PR DESCRIPTION
Use 5 bytes for `NodeIndex` and 10 bytes for `Weight`

Parameterize `Dawg` with type for the Weight class.