### PR TITLE
Add metrics and flags for n_nodes/n_edges ratio to n_tokens

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -19,6 +19,8 @@ time ./target/release/rusty-dawg \
     --save-path "" \
     --results-path "" \
     --n-eval 0 \
+    --nodes-ratio 1.25 \
+    --edges-ratio 2.20 \
     --tokenize
 
 # size=$(ls -lh /tmp/$1.dawg | awk '{print  $5}')

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -6,6 +6,8 @@
     --save-path ~/Desktop/$1.dawg \
     --results-path ~/Desktop/$1.json \
     --n-eval 0 \
+    --nodes-ratio 1.25 \
+    --edges-ratio 2.20 \
     --tokenize
     # -f 0 -f 1024 -f 2048 -f 4096 -f 8192 -f 16384 \
     # -d 0.01 -d 0.05 -d 0.1 -d 0.3 -d 0.5 \

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,11 @@ struct Args {
     n_gram: Vec<i64>,
     #[arg(long, short = 'i')]
     induct_delta: Vec<f64>,
+
+    #[arg(long, default_value_t = 2.)]
+    nodes_ratio: f64,
+    #[arg(long, default_value_t = 3.)]
+    edges_ratio: f64,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -130,7 +135,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     create_lms(&args, &mut gen_lms);
     let mut gen_evaluator = Evaluator::new(&mut gen_lms, &gen, args.max_length);
 
-    let mut dawg: Dawg<E, N> = Dawg::with_capacity(2 * train.len(), 3 * train.len());
+    let n_nodes = (args.nodes_ratio * (train.len() as f64)).ceil() as usize;
+    let n_edges = (args.edges_ratio * (train.len() as f64)).ceil() as usize;
+    let mut dawg: Dawg<E, N> = Dawg::with_capacity(n_nodes, n_edges);
     let mut last = dawg.get_initial();
     for (idx, token) in tqdm!(train.iter()).enumerate() {
         last = dawg.extend(*token, last);
@@ -150,9 +157,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     println!("Completed!");
-    println!("  Node count: {}", dawg.node_count());
-    println!("  Edge count: {}", dawg.edge_count());
-    println!("  balance ratio (q0): {}", dawg.balance_ratio(1));
+    println!("  Node ratio: {:.2} (total={})", (dawg.node_count() as f64) / (train.len() as f64), dawg.node_count());
+    println!("  Edge ratio: {:.2} (total={})", (dawg.edge_count() as f64) / (train.len() as f64), dawg.edge_count());
+    println!("  Balance ratio: {}", dawg.balance_ratio(1));
 
     if !args.save_path.is_empty() {
         println!("Saving DAWG...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     println!("Completed!");
-    println!("  Node ratio: {:.2} (total={})", (dawg.node_count() as f64) / (train.len() as f64), dawg.node_count());
-    println!("  Edge ratio: {:.2} (total={})", (dawg.edge_count() as f64) / (train.len() as f64), dawg.edge_count());
+    println!(
+        "  Node ratio: {:.2} (total={})",
+        (dawg.node_count() as f64) / (train.len() as f64),
+        dawg.node_count()
+    );
+    println!(
+        "  Edge ratio: {:.2} (total={})",
+        (dawg.edge_count() as f64) / (train.len() as f64),
+        dawg.edge_count()
+    );
     println!("  Balance ratio: {}", dawg.balance_ratio(1));
 
     if !args.save_path.is_empty() {


### PR DESCRIPTION
Useful to avoid allocating unnecessary memory if we know the n_nodes and n_edges will be better than the theoretical upper bound

In practice, turns out to be negligible for the benchmarks, but useful option to have for larger datasets