### PR TITLE
Willm/docs

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -21,6 +21,5 @@ time ./target/release/rusty-dawg \
     --n-eval 0 \
     --nodes-ratio 1.25 \
     --edges-ratio 2.20 \
-    --disk-path "/Users/willm/Desktop/dawg" \
     --tokenizer "whitespace"
 

--- a/src/dawg/mod.rs
+++ b/src/dawg/mod.rs
@@ -210,6 +210,10 @@ where
         (new, length + 1)
     }
 
+    pub fn new_document(&self) -> (NodeIndex, u64) {
+        (self.get_initial(), 0)
+    }
+
     // Set the lengths field to store min factor length instead of max factor length.
     pub fn recompute_lengths(&mut self) {
         self._zero_lengths(self.initial);

--- a/src/dawg/mod.rs
+++ b/src/dawg/mod.rs
@@ -218,18 +218,23 @@ where
         (new, length + 1)
     }
 
-    pub fn end_document(&mut self, mut last: NodeIndex, doc_id_token: E, doc_id: u64) -> (NodeIndex, u64) {
+    pub fn end_document(
+        &mut self,
+        mut last: NodeIndex,
+        doc_id_token: E,
+        doc_id: u64,
+    ) -> (NodeIndex, u64) {
         loop {
             match self.transition(last, doc_id_token, false) {
                 Some(doc_state) => {
                     last = doc_state;
-                },
+                }
                 None => {
                     // Add a special node representing the end of a document.
                     let dnode = self.dawg.add_node(W::new(doc_id, None, 0));
                     self.dawg.add_balanced_edge(last, dnode, doc_id_token);
                     break;
-                },
+                }
             }
         }
         (self.get_initial(), 0)
@@ -602,7 +607,7 @@ mod tests {
         assert_eq!(dawg.get_node(q3_abb).get_length(), 3);
         assert_eq!(dawg.get_node(q3_abb).get_count(), 1);
         let doc_abb = dawg.transition(q3_abb, doc_id_token, false).unwrap();
-        assert_eq!(dawg.get_node(doc_abb).get_length(), 0);  // Document ID 0
+        assert_eq!(dawg.get_node(doc_abb).get_length(), 0); // Document ID 0
 
         // Branch of aca.
         let q2_aca = dawg.transition(q1, 'c', false).unwrap();
@@ -614,7 +619,7 @@ mod tests {
         assert_eq!(dawg.get_node(q3_aca).get_count(), 1);
         assert_ne!(q3_abb, q3_aca);
         let doc_aca = dawg.transition(q3_aca, doc_id_token, false).unwrap();
-        assert_eq!(dawg.get_node(doc_aca).get_length(), 1);  // Document ID 1
+        assert_eq!(dawg.get_node(doc_aca).get_length(), 1); // Document ID 1
 
         assert_eq!(dawg.transition(q1, 'a', false), None);
         assert_eq!(dawg.transition(q2_abb, 'a', false), None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,7 @@ where
             None => vec![text],
         };
         for (doc_id, doc) in docs.iter().enumerate() {
-            let tokens = index.tokenize(&doc);
+            let tokens = index.tokenize(doc);
             for token in &tokens {
                 (last, length) = dawg.extend(*token, last, length);
                 if eval_threshold != 0 && idx % eval_threshold == 0 && idx != 0 {


### PR DESCRIPTION
Add logic to parse document boundaries via a string (passed by command line). Also insert document nodes in the graph at the end of a document chain that represent the document ID in the normal length field.