### PR TITLE
Make DiskDawg unsendable

### DIFF
--- a/bindings/python/src/disk_dawg.rs
+++ b/bindings/python/src/disk_dawg.rs
@@ -11,7 +11,7 @@ use rusty_dawg::graph::memory_backing::DiskBacking;
 
 type Mb = DiskBacking<DefaultWeight, usize, DefaultIx>;
 
-#[pyclass]
+#[pyclass(unsendable)]
 pub struct DiskDawg {
     dawg: dawg::Dawg<usize, DefaultWeight, DefaultIx, Mb>,
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,15 +1,15 @@
 use pyo3::prelude::*;
 
 pub mod dawg;
-// pub mod disk_dawg;  // FIXME(#53): Vector type used by disk-backed DAWG is not thread-safe.
+pub mod disk_dawg;
 
 use dawg::Dawg;
-// use disk_dawg::DiskDawg;
+use disk_dawg::DiskDawg;
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn rusty_dawg(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Dawg>()?;
-    // m.add_class::<DiskDawg>()?;
+    m.add_class::<DiskDawg>()?;
     Ok(())
 }


### PR DESCRIPTION
Closes #53 by making `DiskDawg` unsendable between Python threads