### PR TITLE
Change Python bindings to assume u16 tokens

### DIFF
--- a/bindings/python/rusty_dawg/__init__.py
+++ b/bindings/python/rusty_dawg/__init__.py
@@ -1,4 +1,4 @@
-from .rusty_dawg import Dawg
+from .rusty_dawg import Dawg, DiskDawg
 from transformers.tokenization_utils import PreTrainedTokenizer
 from typing import Dict
 

--- a/bindings/python/src/dawg.rs
+++ b/bindings/python/src/dawg.rs
@@ -9,7 +9,7 @@ use rusty_dawg::weight::DefaultWeight;
 
 #[pyclass]
 pub struct Dawg {
-    dawg: dawg::Dawg<usize, DefaultWeight>,
+    dawg: dawg::Dawg<u16, DefaultWeight>,
 }
 
 // Wrap the normal Dawg class with a Python interface.
@@ -26,11 +26,11 @@ impl Dawg {
     pub fn load(_cls: &PyType, path: String) -> PyResult<Self> {
         // let file = fs::OpenOptions::new().read(true).open(&path)?;
         let wrapped_dawg =
-            <dawg::Dawg<usize, DefaultWeight> as Load>::load(&path).expect("Failed to deserialize");
+            <dawg::Dawg<u16, DefaultWeight> as Load>::load(&path).expect("Failed to deserialize");
         Ok(Self { dawg: wrapped_dawg })
     }
 
-    pub fn build(&mut self, text: Vec<usize>) {
+    pub fn build(&mut self, text: Vec<u16>) {
         self.dawg.build(&text);
     }
 
@@ -38,7 +38,7 @@ impl Dawg {
         self.dawg.get_initial().index()
     }
 
-    pub fn transition(&self, state: usize, token: usize, use_failures: bool) -> Option<usize> {
+    pub fn transition(&self, state: usize, token: u16, use_failures: bool) -> Option<usize> {
         let state_index = NodeIndex::new(state);
         match self.dawg.transition(state_index, token, use_failures) {
             Some(q) => Some(q.index()),
@@ -49,7 +49,7 @@ impl Dawg {
     pub fn transition_and_count(
         &self,
         state: usize,
-        token: usize,
+        token: u16,
         length: u64,
     ) -> (Option<usize>, u64) {
         let state_index = NodeIndex::new(state);
@@ -66,7 +66,7 @@ impl Dawg {
     }
 
     // Returns (State, TokenId)
-    pub fn get_edges(&self, state: usize) -> Vec<(usize, usize)> {
+    pub fn get_edges(&self, state: usize) -> Vec<(usize, u16)> {
         let state_index = NodeIndex::new(state);
         let graph = self.dawg.get_graph();
         graph
@@ -89,7 +89,7 @@ impl Dawg {
 }
 
 impl Dawg {
-    pub fn get_dawg(&self) -> &dawg::Dawg<usize, DefaultWeight> {
+    pub fn get_dawg(&self) -> &dawg::Dawg<u16, DefaultWeight> {
         &self.dawg
     }
 }

--- a/bindings/python/src/disk_dawg.rs
+++ b/bindings/python/src/disk_dawg.rs
@@ -9,11 +9,11 @@ use rusty_dawg::weight::{Weight, DefaultWeight};
 use rusty_dawg::graph::indexing::DefaultIx;
 use rusty_dawg::graph::memory_backing::DiskBacking;
 
-type Mb = DiskBacking<DefaultWeight, usize, DefaultIx>;
+type Mb = DiskBacking<DefaultWeight, u16, DefaultIx>;
 
 #[pyclass(unsendable)]
 pub struct DiskDawg {
-    dawg: dawg::Dawg<usize, DefaultWeight, DefaultIx, Mb>,
+    dawg: dawg::Dawg<u16, DefaultWeight, DefaultIx, Mb>,
 }
 
 // Wrap the normal Dawg class with a Python interface.
@@ -27,7 +27,7 @@ impl DiskDawg {
         })
     }
 
-    pub fn build(&mut self, text: Vec<usize>) {
+    pub fn build(&mut self, text: Vec<u16>) {
         self.dawg.build(&text);
     }
 
@@ -35,7 +35,7 @@ impl DiskDawg {
         self.dawg.get_initial().index()
     }
 
-    pub fn transition(&self, state: usize, token: usize, use_failures: bool) -> Option<usize> {
+    pub fn transition(&self, state: usize, token: u16, use_failures: bool) -> Option<usize> {
         let state_index = NodeIndex::new(state);
         match self.dawg.transition(state_index, token, use_failures) {
             Some(q) => Some(q.index()),
@@ -46,7 +46,7 @@ impl DiskDawg {
     pub fn transition_and_count(
         &self,
         state: usize,
-        token: usize,
+        token: u16,
         length: u64,
     ) -> (Option<usize>, u64) {
         let state_index = NodeIndex::new(state);
@@ -63,7 +63,7 @@ impl DiskDawg {
     }
 
     // Returns (State, TokenId)
-    pub fn get_edges(&self, state: usize) -> Vec<(usize, usize)> {
+    pub fn get_edges(&self, state: usize) -> Vec<(usize, u16)> {
         let state_index = NodeIndex::new(state);
         let graph = self.dawg.get_graph();
         graph
@@ -86,7 +86,7 @@ impl DiskDawg {
 }
 
 impl DiskDawg {
-    pub fn get_dawg(&self) -> &dawg::Dawg<usize, DefaultWeight, DefaultIx, Mb> {
+    pub fn get_dawg(&self) -> &dawg::Dawg<u16, DefaultWeight, DefaultIx, Mb> {
         &self.dawg
     }
 }

--- a/scripts/test_python_library.py
+++ b/scripts/test_python_library.py
@@ -1,0 +1,27 @@
+from transformers import AutoTokenizer
+
+from rusty_dawg import Dawg, DiskDawg
+
+def test_new_ram():
+    dawg = Dawg()
+    dawg.build([21, 34, 32])
+
+def test_load_disk():
+    path = "/tmp/wikitext-2-raw-dawg"
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    dawg = DiskDawg.load(path)
+
+    tokens = tokenizer("the cat saw the world in the bottle").input_ids
+    state = dawg.get_initial()
+    length = 0
+    lengths = []
+    for token in tokens:
+        state, length = dawg.transition_and_count(state, token, length)
+        lengths.append(length)
+    
+    print(tokenizer.convert_ids_to_tokens(tokens))
+    print(lengths)
+
+if __name__ == "__main__":
+    test_new_ram()
+    test_load_disk()


### PR DESCRIPTION
Changed the wrapped Rust classes to use `u16` instead of `usize` (unintended before). Should make them a lot more memory efficient!